### PR TITLE
Adjusted dataElementGroup selection to avoid overwriting existing tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "chartist-plugin-screentips",
+  "name": "chartist-plugin-screentips-custom",
   "description": "Screen tips Plugin for Chartist.js",
   "version": "0.0.19",
   "author": "Markus Padourek (upgraded by Develoger)",
   "homepage": "https://github.com/radojesrb/chartist-plugin-tooltip",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radojesrb/chartist-plugin-tooltip.git"
+    "url": "git+https://github.com/claudiobmgrtnr/chartist-plugin-tooltip.git"
   },
   "bugs": {
-    "url": "https://github.com/radojesrb/chartist-plugin-tooltip/issues"
+    "url": "https://github.com/claudiobmgrtnr/chartist-plugin-tooltip/issues"
   },
   "keywords": [
     "chartist",

--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -152,9 +152,8 @@
           // donut support
           dataPoint = series;
           tooltipContent = dataPoint.tooltip || dataPoint.value;
-          // get data element, required to set tooltip content to its parent
-          dataElement = document.querySelector('.' + dataElement._node.getAttribute('class') + '[value="' + dataPoint.value + '"]');
-          var dataElementGroup = dataElement.parentNode;
+          // get parent node of dataElement node
+          var dataElementGroup = data.group.getNode();
           dataElementGroup.setAttribute('data-tooltip', tooltipContent);
         }
       });


### PR DESCRIPTION
Hey man :) long time no hear. 
We ran into a little problem with your current fork of the tooltip-library. So I came up with fix. Would be awesome, if you could merge my code and mage another release of your npm package

Using the code as it is, it would not be possible to have two pie-chart slices with the same value since the querySelector matches all existing slices. The consequence would be, that the tooltip of the second pie-chart slice overwrites the first one.

Cheers